### PR TITLE
TIMOB-13626 - Prevented click event from firing after touch move

### DIFF
--- a/src/tibb/NativeControlObject.h
+++ b/src/tibb/NativeControlObject.h
@@ -243,18 +243,18 @@ private slots:
 
         switch (event->touchType()) {
             case bb::cascades::TouchType::Down:
-            	startPointX = x;
-            	startPointY = y;
+                startPointX = x;
+                startPointY = y;
                 emit touchStart(x, y);
                 break;
             case bb::cascades::TouchType::Move:
                 emit touchMove(x, y);
                 break;
             case bb::cascades::TouchType::Up:
-            	if(startPointX == x && startPointY == y) {
+                if(startPointX == x && startPointY == y) {
                     emit click(x, y);
                     break;
-            	}
+                }
                 emit touchEnd(x, y);
                 break;
             case bb::cascades::TouchType::Cancel:

--- a/src/tibb/NativeControlObject.h
+++ b/src/tibb/NativeControlObject.h
@@ -220,6 +220,9 @@ public:
                          this, SLOT(onNodeDestroyed()));
         connect(node, SIGNAL(focusedChanged(bool)), SLOT(focusedChanged(bool)));
     }
+private:
+    float startPointX;
+    float startPointY;
 
 signals:
     void click(float x, float y);
@@ -237,19 +240,21 @@ private slots:
               y = event->localY();
 
         // TODO(josh): Include coordinates of "click".
-        // TODO(josh): Click should only happen with no movement (down & up).
-        if (event->touchType() == bb::cascades::TouchType::Up) {
-            emit click(x, y);
-        }
 
         switch (event->touchType()) {
             case bb::cascades::TouchType::Down:
+            	startPointX = x;
+            	startPointY = y;
                 emit touchStart(x, y);
                 break;
             case bb::cascades::TouchType::Move:
                 emit touchMove(x, y);
                 break;
             case bb::cascades::TouchType::Up:
+            	if(startPointX == x && startPointY == y) {
+                    emit click(x, y);
+                    break;
+            	}
                 emit touchEnd(x, y);
                 break;
             case bb::cascades::TouchType::Cancel:


### PR DESCRIPTION
Test code:

```
var win = Ti.UI.createWindow({
    backgroundColor: 'white'
});

var scrollView = Ti.UI.createScrollView({
    backgroundColor: 'white',
    layout: 'vertical',
    contentWidth: Ti.UI.FILL,
    contentHeight: Ti.UI.SIZE
});

for(var i = 0; i < 20; i++) {
    var btn = Ti.UI.createButton({
        top: 10,
        title: 'Hello'
    });
    scrollView.add(btn);
}

win.add(scrollView);

scrollView.addEventListener('click', function(e){
    Ti.API.info(JSON.stringify(e));
});

win.open();
```
