### PR TITLE
[TIMOB-13815] Blackberry: Can't identify functions via JS on Titanium proxy objects

### DIFF
--- a/src/tibb/TiGenericFunctionObject.h
+++ b/src/tibb/TiGenericFunctionObject.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -29,9 +29,10 @@ public:
 
 protected:
     virtual ~TiGenericFunctionObject();
-    virtual Handle<Value> onFunctionCall(const Arguments& args);
 
 private:
+    static Handle<Value> onInvoke(const Arguments& args);
+
     TiGenericFunctionObject();
     TiGenericFunctionObject(const char* name);
     void* context_;


### PR DESCRIPTION
Fix a bug when trying to determine the type of a proxy method.
Previously the type would be object since we just used callable objects.
This patch switches to using real functions (via FunctionTemplate).

See JIRA ticket for test cases.
