### PR TITLE
[TIMOB-13939] BlackBerry: Builds failing on CI due to compile error.

### DIFF
--- a/src/tibb/TiUtils.cpp
+++ b/src/tibb/TiUtils.cpp
@@ -6,10 +6,15 @@
  */
 
 #include "TiUtils.h"
-#include "Layout/ParseProperty.h"
+
+#include <math.h>
+
 #include <bb/device/DisplayInfo>
+
 #include <QObject>
 #include <QString>
+
+#include "Layout/ParseProperty.h"
 
 static TiUtils* sharedInstance = NULL;
 


### PR DESCRIPTION
A fix for a compile error that was breaking the CI builds.
