### PR TITLE
[TIMOB-13967] BlackBerry : Layout crashes if we touch the views before it finishes laying out the whole layout

### DIFF
--- a/src/tibb/NativeScrollViewObject.cpp
+++ b/src/tibb/NativeScrollViewObject.cpp
@@ -29,8 +29,11 @@ void NativeScrollViewContentObject::updateLayout(QRectF rect)
     NativeControlObject::updateLayout(rect);
     scrollView_->setContentWidthAndHeight(rect.width(), rect.height());
 }
+
 NativeScrollViewObject::NativeScrollViewObject(TiObject* tiObject)
     : NativeControlObject(tiObject, N_TYPE_SCROLL_VIEW)
+    , contentWidthSet_(false)
+    , contentHeightSet_(false)
 {
     scrollView_ = NULL;
 }
@@ -66,6 +69,7 @@ int NativeScrollViewObject::setLayout(TiObject *obj)
 		err = contentViewProxy_->setWidth(&width);
 	}
 	err = contentViewProxy_->setLayout(obj);
+
 	return err;
 }
 void NativeScrollViewObject::setContentWidthAndHeight(float width, float height)


### PR DESCRIPTION
Fixes an issue in scroll view which would prevent the content view
from being properly sized. This was caused by an un-initialized internal flag
which would be randomly set.

See JIRA ticket for a test case. Launch the app over and over to verify
the bad behavior no longer occurs. A few dozen launches should give you a good
indication it no longer occurs.
