### PR TITLE
[TIMOB-14068] Copy BlackBerry resources from SDK if not in project.

### DIFF
--- a/build_templates/blackberry/cli/common/blackberryndk.js
+++ b/build_templates/blackberry/cli/common/blackberryndk.js
@@ -125,7 +125,13 @@ var package = function(builder) {
     // blackberry resources start at assets
 	if (fs.existsSync(blackberryRes)) { wrench.rmdirSyncRecursive(blackberryRes); }
 
-	afs.copyDirSyncRecursive(path.join(resourcesDir, 'blackberry'),
+	var blackberryResSrc = path.join(resourcesDir, 'blackberry');
+	if (!fs.existsSync(blackberryResSrc) ||
+	    fs.readdirSync(blackberryResSrc).length == 0) {
+		blackberryResSrc = path.join(titaniumBBSdkPath, 'templates', 'app', 'default', 'Resources', 'blackberry');
+	}
+
+	afs.copyDirSyncRecursive(blackberryResSrc,
 	 									path.join(buildDir, 'assets'), { preserve: true, logger: logger.debug });
 
 	var appPropsFile = path.join(buildDir, 'assets', 'app_properties.ini');


### PR DESCRIPTION
If the Resources/blackberry folder does not exist
or is empty, fall back gracefully to the SDK templates.

See JIRA ticket for testing details.
