### PR TITLE
[TIMOB-13971] Changed dip value from 96 to 160

### DIFF
--- a/src/tibb/Layout/ParseProperty.cpp
+++ b/src/tibb/Layout/ParseProperty.cpp
@@ -70,7 +70,7 @@ double _computeValue(std::string value, enum ValueType valueType, double ppi) {
 	  	  return parsedValue;
 	  }
 	  else if (units == "dp" || units == "dip") {
-	  	  return parsedValue * (ppi/96); // 96 - http://en.wikipedia.org/wiki/Dots_per_inch
+	  	  return parsedValue * (ppi / 160); // 160 - http://developer.blackberry.com/cascades/documentation/ui/webview/javascript.html
 	  }
 	}
 	else {


### PR DESCRIPTION
This is the only place in the documentation that mentions DPI, and it is set to 160, look for "This setting scales the webpage to 160 dpi,"

http://developer.blackberry.com/cascades/documentation/ui/webview/javascript.html
