### PR TITLE
[TIMOB-14781] Backport to 3.1.X

### DIFF
--- a/build_templates/blackberry/cli/common/blackberryndk.js
+++ b/build_templates/blackberry/cli/common/blackberryndk.js
@@ -406,19 +406,20 @@ function BlackberryNDK(builder) {
 			var oldPath = process.cwd()	
 			var tmpPathProj = path.join(os.tmpDir(), generateTmpName(projectName)); 
 			var projectDir = this.builder.projectDir;
-			afs.copyDirSyncRecursive(projectDir, tmpPathProj, {logger: logger.debug});
-			process.chdir(path.join(tmpPathProj, 'build', 'blackberry'));
+
+			afs.copyDirSyncRecursive(path.join(projectDir, 'build'), tmpPathProj, {logger: logger.debug});
+			process.chdir(path.join(tmpPathProj, 'blackberry'));
 
 			header_paths.forEach(function(entry) {
-			    fs.createReadStream(entry.path).pipe(fs.createWriteStream(path.join(tmpPathProj, 'build', 'blackberry', entry.name)));
+			    fs.createReadStream(entry.path).pipe(fs.createWriteStream(path.join(tmpPathProj, 'blackberry', entry.name)));
 			 });
 
-			var common_make_file_path = path.join(tmpPathProj, 'build', 'blackberry', 'common.mk');
+			var common_make_file_path = path.join(tmpPathProj, 'blackberry', 'common.mk');
 			fs.writeFileSync(common_make_file_path, renderTemplate(fs.readFileSync(common_make_file_path).toString().trim(), {
 				libs: lib_names
 			}));
 
-			var main_file_path = path.join(tmpPathProj, 'build', 'blackberry', 'main.cpp');
+			var main_file_path = path.join(tmpPathProj, 'blackberry', 'main.cpp');
 			fs.writeFileSync(main_file_path, renderTemplate(fs.readFileSync(main_file_path).toString().trim(), {
 				module_headers: headers,
 				module_registration: register_modules
@@ -434,7 +435,7 @@ function BlackberryNDK(builder) {
 			}
 
 			runCommandFromArray([srccmd, '&&', 'make', tiappName, cpuList, bbRoot, debug], showCmd = true, function() {
-				afs.copyDirSyncRecursive(tmpPathProj, projectDir, {logger: logger.debug});
+				afs.copyDirSyncRecursive(tmpPathProj, path.join(projectDir, 'build'), {logger: logger.debug});
 
 				try {
 					wrench.rmdirSyncRecursive(tmpPathSDK);


### PR DESCRIPTION
do not copy over resources during build so that timestamp on resources stays the same
